### PR TITLE
23-05-23 Design Pattern & Refactoring #3

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Blizzard.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Blizzard.java
@@ -24,9 +24,8 @@ package com.shatteredpixel.shatteredpixeldungeon.actors.blobs;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.effects.BlobEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Speck;
-import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 
-public class Blizzard extends Blob {
+public class Blizzard extends Nature {
 	
 	@Override
 	protected void evolve() {
@@ -43,9 +42,8 @@ public class Blizzard extends Blob {
 			for (int j = area.top; j < area.bottom; j++) {
 				cell = i + j * Dungeon.level.width();
 				if (cur[cell] > 0) {
-					
-					if (fire != null)   fire.clear(cell);
-					if (freeze != null) freeze.clear(cell);
+
+					clearFireFreeze(fire, freeze, cell);
 					
 					if (inf != null && inf.volume > 0 && inf.cur[cell] > 0){
 						inf.clear(cell);
@@ -66,11 +64,5 @@ public class Blizzard extends Blob {
 		super.use( emitter );
 		emitter.pour( Speck.factory( Speck.BLIZZARD, true ), 0.4f );
 	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
-	}
-	
-	
+
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Electricity.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Electricity.java
@@ -37,7 +37,7 @@ import com.shatteredpixel.shatteredpixeldungeon.utils.GLog;
 import com.watabou.utils.PathFinder;
 import com.watabou.utils.Random;
 
-public class Electricity extends Blob {
+public class Electricity extends Nature {
 	
 	{
 		//acts after mobs, to give them a chance to resist paralysis
@@ -119,11 +119,6 @@ public class Electricity extends Blob {
 	public void use( BlobEmitter emitter ) {
 		super.use( emitter );
 		emitter.start( SparkParticle.FACTORY, 0.05f, 0 );
-	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
 	}
 	
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Fire.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Fire.java
@@ -29,11 +29,10 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Burning;
 import com.shatteredpixel.shatteredpixeldungeon.effects.BlobEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.FlameParticle;
 import com.shatteredpixel.shatteredpixeldungeon.items.Heap;
-import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.plants.Plant;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 
-public class Fire extends Blob {
+public class Fire extends Nature {
 
 	@Override
 	protected void evolve() {
@@ -118,9 +117,5 @@ public class Fire extends Blob {
 		super.use( emitter );
 		emitter.pour( FlameParticle.FACTORY, 0.03f );
 	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
-	}
+
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Foliage.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Foliage.java
@@ -29,10 +29,9 @@ import com.shatteredpixel.shatteredpixeldungeon.effects.BlobEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.ShaftParticle;
 import com.shatteredpixel.shatteredpixeldungeon.journal.Notes;
 import com.shatteredpixel.shatteredpixeldungeon.levels.Terrain;
-import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 
-public class Foliage extends Blob {
+public class Foliage extends Nature {
 	
 	@Override
 	protected void evolve() {
@@ -81,9 +80,5 @@ public class Foliage extends Blob {
 		super.use( emitter );
 		emitter.start( ShaftParticle.FACTORY, 0.9f, 0 );
 	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
-	}
+
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Freezing.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Freezing.java
@@ -32,9 +32,8 @@ import com.shatteredpixel.shatteredpixeldungeon.effects.CellEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.SnowParticle;
 import com.shatteredpixel.shatteredpixeldungeon.items.Heap;
 import com.shatteredpixel.shatteredpixeldungeon.levels.rooms.special.MagicalFireRoom;
-import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 
-public class Freezing extends Blob {
+public class Freezing extends Nature {
 	
 	@Override
 	protected void evolve() {
@@ -93,11 +92,6 @@ public class Freezing extends Blob {
 	public void use( BlobEmitter emitter ) {
 		super.use( emitter );
 		emitter.start( SnowParticle.FACTORY, 0.05f, 0 );
-	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
 	}
 	
 	//legacy functionality from before this was a proper blob. Returns true if this cell is visible

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/GooWarn.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/GooWarn.java
@@ -28,7 +28,7 @@ import com.shatteredpixel.shatteredpixeldungeon.effects.BlobEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.GooSprite;
 
-public class GooWarn extends Blob {
+public class GooWarn extends Nature {
 
 	//cosmetic blob, used to warn noobs that goo's pump up should, infact, be avoided.
 
@@ -61,11 +61,6 @@ public class GooWarn extends Blob {
 	public void use( BlobEmitter emitter ) {
 		super.use( emitter );
 		emitter.pour(GooSprite.GooParticle.FACTORY, 0.03f );
-	}
-
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
 	}
 }
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Inferno.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Inferno.java
@@ -24,10 +24,9 @@ package com.shatteredpixel.shatteredpixeldungeon.actors.blobs;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.effects.BlobEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Speck;
-import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 
-public class Inferno extends Blob {
+public class Inferno extends Nature {
 	
 	@Override
 	protected void evolve() {
@@ -46,8 +45,7 @@ public class Inferno extends Blob {
 				cell = i + j * Dungeon.level.width();
 				if (cur[cell] > 0) {
 					
-					if (fire != null)   fire.clear(cell);
-					if (freeze != null) freeze.clear(cell);
+					clearFireFreeze(fire, freeze, cell);
 					
 					if (bliz != null && bliz.volume > 0 && bliz.cur[cell] > 0){
 						bliz.clear(cell);
@@ -89,10 +87,4 @@ public class Inferno extends Blob {
 		
 		emitter.pour( Speck.factory( Speck.INFERNO, true ), 0.4f );
 	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
-	}
-	
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Nature.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Nature.java
@@ -1,0 +1,14 @@
+package com.shatteredpixel.shatteredpixeldungeon.actors.blobs;
+
+import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
+
+public class Nature extends Blob{
+    protected void clearFireFreeze(Fire fire, Freezing freeze, int cell) {
+        if (fire != null)   fire.clear(cell);
+        if (freeze != null) freeze.clear(cell);
+    }
+
+    public String tileDesc() {
+        return Messages.get(this, "desc");
+    }
+}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/SacrificialFire.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/SacrificialFire.java
@@ -49,7 +49,7 @@ import com.watabou.utils.Bundle;
 import com.watabou.utils.PathFinder;
 import com.watabou.utils.Random;
 
-public class SacrificialFire extends Blob {
+public class SacrificialFire extends Nature {
 
 	BlobEmitter curEmitter;
 
@@ -114,11 +114,6 @@ public class SacrificialFire extends Blob {
 		//a bit brittle, assumes only one tile of sacrificial fire can exist per floor
 		int max = 6 + Dungeon.depth * 4;
 		curEmitter.pour( SacrificialParticle.FACTORY, 0.01f + ((volume / (float)max) * 0.09f) );
-	}
-
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
 	}
 
 	private static final String BONUS_SPAWNS = "bonus_spawns";

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/SmokeScreen.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/SmokeScreen.java
@@ -25,17 +25,11 @@ import com.shatteredpixel.shatteredpixeldungeon.effects.BlobEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Speck;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 
-public class SmokeScreen extends Blob {
+public class SmokeScreen extends Nature {
 	
 	@Override
 	public void use( BlobEmitter emitter ) {
 		super.use( emitter );
 		emitter.pour( Speck.factory( Speck.SMOKE ), 0.1f );
 	}
-
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
-	}
-	
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/StormCloud.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/StormCloud.java
@@ -26,7 +26,7 @@ import com.shatteredpixel.shatteredpixeldungeon.effects.BlobEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Speck;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 
-public class StormCloud extends Blob {
+public class StormCloud extends Nature{
 	
 	@Override
 	protected void evolve() {
@@ -47,16 +47,10 @@ public class StormCloud extends Blob {
 			}
 		}
 	}
-	
+
 	@Override
 	public void use( BlobEmitter emitter ) {
 		super.use( emitter );
 		emitter.pour( Speck.factory( Speck.STORM ), 0.4f );
 	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
-	}
-	
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/WaterOfAwareness.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/WaterOfAwareness.java
@@ -97,9 +97,4 @@ public class WaterOfAwareness extends WellWater {
 		super.use( emitter );
 		emitter.pour( Speck.factory( Speck.QUESTION ), 0.3f );
 	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
-	}
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/WaterOfHealth.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/WaterOfHealth.java
@@ -97,9 +97,4 @@ public class WaterOfHealth extends WellWater {
 		super.use( emitter );
 		emitter.start( Speck.factory( Speck.HEALING ), 0.5f, 0 );
 	}
-	
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
-	}
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Web.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/Web.java
@@ -31,7 +31,7 @@ import com.shatteredpixel.shatteredpixeldungeon.levels.Level;
 import com.shatteredpixel.shatteredpixeldungeon.levels.Terrain;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 
-public class Web extends Blob {
+public class Web extends Nature {
 
 	{
 		//acts before the hero, to ensure terrain is adjusted correctly
@@ -99,10 +99,5 @@ public class Web extends Blob {
 				l.flamable[i] = l.flamable[i] || cur[i] > 0;
 			}
 		}
-	}
-
-	@Override
-	public String tileDesc() {
-		return Messages.get(this, "desc");
 	}
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/WellWater.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/WellWater.java
@@ -32,7 +32,7 @@ import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 import com.watabou.utils.PathFinder;
 import com.watabou.utils.Random;
 
-public abstract class WellWater extends Blob {
+public abstract class WellWater extends Nature {
 
 	@Override
 	protected void evolve() {


### PR DESCRIPTION
Refactoring 적용 대상
: Blizzard, Inferno 외 12개의 클래스

적용한 Refactoring 이름
: Extract Method, move method

(1)의 Refactoring Operation을 적용한 이유
:14개의 Class 에서 중복되는 함수인 tileDesc를 move method로 옮겨서 중복코드를 없애고, Blizzard, Inferno에서 중복되는 부분을 
Extract Method로 추출하고 Move Method를 이용해 옮겼다.